### PR TITLE
Fix HTTPS redirect

### DIFF
--- a/kbf-web/helpers.php
+++ b/kbf-web/helpers.php
@@ -74,7 +74,7 @@ function error($error) {
 
 function forceHttps($config) {
 	if($config["environment"] === "prod") {
-		if($_SERVER["HTTPS"] != "on") {
+		if(!array_key_exists("HTTPS", $_SERVER) || $_SERVER["HTTPS"] != "on") {
 			header("Location: https://" . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"]);
 			exit();
 		}


### PR DESCRIPTION
Fix the HTTPS redirect by checking if the HTTPS key exists before trying to check the value.
This avoids a warning (when display_errors is On) that breaks the redirect:
Warning: Undefined array key "HTTPS" in ...helpers.php on line 77
Warning: Cannot modify header information - headers already sent by ...